### PR TITLE
Add circle_fixture for use B2DCircleShape

### DIFF
--- a/lib/joybox/box2d/body.rb
+++ b/lib/joybox/box2d/body.rb
@@ -45,11 +45,11 @@ class B2DBody
     edge_shape = B2DEdgeShape.alloc.initWithStartPoint(start_point.to_pixel_coordinates,
                                                        endPoint: end_point.to_pixel_coordinates)
 
-    addFixureForShape(edge_shape,
-                      friction: options[:friction],
-                      restitution: options[:restitution],
-                      density: options[:density],
-                      isSensor: options[:is_sensor])
+    addFixtureForShape(edge_shape,
+                       friction: options[:friction],
+                       restitution: options[:restitution],
+                       density: options[:density],
+                       isSensor: options[:is_sensor])
   end
 
 
@@ -63,23 +63,23 @@ class B2DBody
 
     polygon_shape = B2DPolygonShape.alloc.initWithBoxSize(box_size.to_pixel_coordinates)
 
-    addFixureForShape(polygon_shape,
-                      friction: options[:friction],
-                      restitution: options[:restitution],
-                      density: options[:density],
-                      isSensor: options[:is_sensor])
+    addFixtureForShape(polygon_shape,
+                       friction: options[:friction],
+                       restitution: options[:restitution],
+                       density: options[:density],
+                       isSensor: options[:is_sensor])
   end
 
-  def circle_fixure(*hash)
+  def circle_fixture(*hash)
     options = hash.pop
-    options = options.nil? ? fixure_defaults : fixure_defaults.merge!(options)
+    options = options.nil? ? fixture_defaults : fixture_defaults.merge!(options)
 
     circle_shape = B2DCircleShape.alloc.initWithRadius(options[:radius].to_pixels)
-    addFixureForShape(circle_shape,
-                      friction: options[:friction],
-                      restitution: options[:restitution],
-                      density: options[:density],
-                      isSensor: options[:is_sensor])
+    addFixtureForShape(circle_shape,
+                       friction: options[:friction],
+                       restitution: options[:restitution],
+                       density: options[:density],
+                       isSensor: options[:is_sensor])
   end
 
   def apply_force_defaults

--- a/lib/joybox/box2d/body.rb
+++ b/lib/joybox/box2d/body.rb
@@ -70,6 +70,17 @@ class B2DBody
                       isSensor: options[:is_sensor])
   end
 
+  def circle_fixure(*hash)
+    options = hash.pop
+    options = options.nil? ? fixure_defaults : fixure_defaults.merge!(options)
+
+    circle_shape = B2DCircleShape.alloc.initWithRadius(options[:radius].to_pixels)
+    addFixureForShape(circle_shape,
+                      friction: options[:friction],
+                      restitution: options[:restitution],
+                      density: options[:density],
+                      isSensor: options[:is_sensor])
+  end
 
   def apply_force_defaults
     {


### PR DESCRIPTION
Add circle_fixture to using circle body.

```
ball_body = @world.new_body(
  position: [Screen.half_width, Screen.half_height],
  type: KDynamicBodyType
) do
  circle_fixure(
    radius: 100,
    friction: 0.6,
    restitution: 0.6,
    density: 2.0
  )
end
```

This code requires this pull-request.
https://github.com/CurveBeryl/Joybox-Box2D/pull/2
You need to merge it and build Box2D.framework before merge this request.
