### PR TITLE
Fix typo in continuousPhysics property/setting

### DIFF
--- a/motion/joybox/physics/world.rb
+++ b/motion/joybox/physics/world.rb
@@ -7,7 +7,7 @@ module Joybox
         {
           gravity: [0, 0],
           allows_sleeping: true,
-          continuos_physics: true
+          continuous_physics: true
         }
       end
 
@@ -16,11 +16,11 @@ module Joybox
 
         options = options.nil? ? defaults : defaults.merge!(options)
 
-        world = World.alloc.init 
+        world = World.alloc.init
 
         world.gravity = options[:gravity]
         world.allowsSleeping = options[:allows_sleeping]
-        world.continuosPhysics = options[:continuos_physics]
+        world.continuousPhysics = options[:continuous_physics]
 
         world
       end
@@ -38,7 +38,7 @@ module Joybox
 
         options = options.nil? ? step_defaults : step_defaults.merge!(options)
 
-        stepWithDelta(options[:delta], 
+        stepWithDelta(options[:delta],
           velocityInteractions: options[:velocity_interactions],
           positionInteractions: options[:position_interactions])
       end


### PR DESCRIPTION
It looks like continuousPhysics was also misspelled here as
in https://github.com/CurveBeryl/Joybox-Box2D/pull/4. The other
vendored files affected in this project, but not changed in
this pull request are:

`vendor/vendor-ios/Box2D.framework/Box2D.framework.bridgesupport`
`vendor/vendor-ios/Box2D.framework/Versions/A/Headers/Dynamics/B2DWorld.h`
`vendor/vendor-osx/box_2d/box_2d.bridgesupport`
`vendor/vendor-osx/box_2d/include/B2DWorld.h`

I assume those will be updated when you pull in the vendored
changes, but let me know if I should update those files as well.
