### PR TITLE
Fix misspelling from jbpLenght to jbpLength

### DIFF
--- a/motion/joybox/actions/fade.rb
+++ b/motion/joybox/actions/fade.rb
@@ -25,11 +25,9 @@ module Joybox
       end
 
       def self.to(options = {})
-        p "========================="
         options = options.nil? ? defaults : defaults.merge!(options)
-        p options
 
-        CCFadeTo.actionWithDuration(options[:duration], 
+        CCFadeTo.actionWithDuration(options[:duration],
                                     opacity: options[:opacity])
       end
 

--- a/motion/joybox/macros.rb
+++ b/motion/joybox/macros.rb
@@ -84,18 +84,18 @@ module Joybox
     end
 
     # Distance between point an origin
-    def jbpLenght(point)
+    def jbpLength(point)
       Math.sqrt(jbpLengthSQ(point))
     end
 
     # Distance between two points
     def jbpDistance(first_point, second_point)
-      jbpLenght(jbpSub(first_point, second_point))
+      jbpLength(jbpSub(first_point, second_point))
     end
 
     # Point multiplied to a lenght of 1
     def jbpNormalize(point)
-      jbpMult(point, 1.0 / jbpLenght(point))
+      jbpMult(point, 1.0 / jbpLength(point))
     end
 
     # Converts radians to a normalized vector


### PR DESCRIPTION
I'll make the corresponding changes in the https://github.com/CurveBeryl/Joybox-Examples/tree/master/Animations projects and reference this pull request.
