### PR TITLE
Refactored OSX App Delegates

### DIFF
--- a/template/joybox-osx-example-repl/files/app/app_delegate.rb
+++ b/template/joybox-osx-example-repl/files/app/app_delegate.rb
@@ -10,23 +10,33 @@ class AppDelegate
   def applicationDidFinishLaunching(notification)
     buildMenu
     buildWindow
+
+    director.run_with_scene(GameScene.new)
   end
 
   def buildWindow
-    @director = Joybox::Configuration.setup do
+    main_window.title = NSBundle.mainBundle.infoDictionary['CFBundleName']
+    main_window.contentView.addSubview(director.view)
+    main_window.orderFrontRegardless
+    main_window.setAcceptsMouseMovedEvents(true)
+    main_window.center
+  end
+
+  def director
+    @director ||= Joybox::Configuration.setup do
       director display_stats: true
       debug repl:true
     end
+  end
 
-    @main_window = NSWindow.alloc.initWithContentRect([[240, 180], [1024, 768]],
+  def main_window_size
+    [1024, 768]
+  end
+
+  def main_window
+    @main_window ||= NSWindow.alloc.initWithContentRect([[0, 0], main_window_size ],
       styleMask: NSTitledWindowMask|NSClosableWindowMask|NSMiniaturizableWindowMask|NSResizableWindowMask,
       backing: NSBackingStoreBuffered,
       defer: false)
-
-    @main_window.title = NSBundle.mainBundle.infoDictionary['CFBundleName']
-    @main_window.contentView.addSubview(@director.view)
-    @main_window.orderFrontRegardless
-
-    @director.run_with_scene(GameScene.new)
   end
 end

--- a/template/joybox-osx/files/app/app_delegate.rb
+++ b/template/joybox-osx/files/app/app_delegate.rb
@@ -2,22 +2,32 @@ class AppDelegate
   def applicationDidFinishLaunching(notification)
     buildMenu
     buildWindow
+
+    director.run_with_scene(DefaultLayer.scene)
   end
 
   def buildWindow
-    @director = Joybox::Configuration.setup do
+    main_window.title = NSBundle.mainBundle.infoDictionary['CFBundleName']
+    main_window.contentView.addSubview(director.view)
+    main_window.orderFrontRegardless
+    main_window.setAcceptsMouseMovedEvents(true)
+    main_window.center
+  end
+
+  def main_window_size
+    [800, 600]
+  end
+
+  def director
+    @director ||= Joybox::Configuration.setup do
       director display_stats: true
     end
+  end
 
-    @main_window = NSWindow.alloc.initWithContentRect([[240, 180], [480, 360]],
+  def main_window
+    @main_window ||= NSWindow.alloc.initWithContentRect([[0, 0], main_window_size],
       styleMask: NSTitledWindowMask|NSClosableWindowMask|NSMiniaturizableWindowMask|NSResizableWindowMask,
       backing: NSBackingStoreBuffered,
       defer: false)
-
-    @main_window.title = NSBundle.mainBundle.infoDictionary['CFBundleName']
-    @main_window.contentView.addSubview(@director.view)
-    @main_window.orderFrontRegardless
-
-    @director.run_with_scene(DefaultLayer.scene)
   end
 end


### PR DESCRIPTION
- Scene start is now clearly within the ApplicationDidFinishLauching
- Removal of instance variables and using getter methods with memoization
- Size of the window is now clearly defined in a method
- Window is automatically centered on the screen
- Window automatically accepts mouse movement events
