### PR TITLE
Support text alignment for Joybox::UI::Label

### DIFF
--- a/motion/joybox/ui/label.rb
+++ b/motion/joybox/ui/label.rb
@@ -2,33 +2,38 @@ module Joybox
   module UI
 
     class Label < CCLabelTTF
-
       alias_method :text=, :setString
       alias_method :set_text, :setString
+
+      TextAlignmentLeft = 0
+      TextAlignmentCenter = 1
+      TextAlignmentRight = 2
 
       def self.defaults
         {
           text: '',
+          dimensions: CGSizeZero,
+          alignment: TextAlignmentCenter,
           font_name: 'Marker Felt',
           font_size: 12
         }
       end
 
-
       def self.new(options = {})
-
         options = options.nil? ? defaults : defaults.merge!(options)
 
-        label = Label.labelWithString(options[:text], 
-                                      fontName: options[:font_name], 
-                                      fontSize: options[:font_size])
+        label = Label.labelWithString(options[:text],
+          dimensions: options[:dimensions],
+          hAlignment: options[:alignment],
+          fontName: options[:font_name],
+          fontSize: options[:font_size]
+        )
 
         label.position = options[:position] if options.has_key? (:position)
         label.color = options[:color] if options.has_key? (:color)
 
         label
       end
-
     end
 
   end


### PR DESCRIPTION
Add alignment & dimensions option to Joybox::UI::Label.
For example

```
label = Label.new(text: "Text"
  font_size: 20,
  color: Color.new(255, 255, 255),
  position: [Screen.width - LABEL_WIDTH, Screen.height - LABEL_HEIGHT],
  dimensions: CGSizeMake(LABEL_WIDTH, LABEL_HEIGHT),
  alignment: Joybox::UI::Label::TextAlignmentRight
)
```
