### PR TITLE
Only take position from body member in PhysicsSprite if the body member is set

### DIFF
--- a/motion/joybox/physics/physics_sprite.rb
+++ b/motion/joybox/physics/physics_sprite.rb
@@ -17,11 +17,17 @@ module Joybox
       end
 
       def position=(position)
-        @body.position = position
+        if @body
+          @body.position = position
+        end
       end
 
       def position
-        @body.position.from_pixel_coordinates
+        if @body
+          @body.position.from_pixel_coordinates
+        else
+          [0,0]
+        end  
       end
 
       def nodeToParentTransform


### PR DESCRIPTION
If you try to use a PhysicsSprite without passing a body parameter in to the constructor everything will explode, as sprite.rb:19 manipulates the position property of the object. As the body parameter is optional this seems like it is a bug to me.

This patch changes it so that the position is only take from the body object if it exists. This is useful if you want to create a physics sprite, and then create the body based on the attributes of it's visual appearance (which are only available after construction).
