### PR TITLE
Fix scaling bug with physics sprite

### DIFF
--- a/motion/joybox/physics/physics_sprite.rb
+++ b/motion/joybox/physics/physics_sprite.rb
@@ -49,7 +49,8 @@ module Joybox
           y = y + sine * -anchorPointInPoints.x + cosine * -anchorPointInPoints.y        
         end
 
-        CGAffineTransformMake(cosine, sine, -sine, cosine, x, y)
+        rotated_transform = CGAffineTransformMake(cosine, sine, -sine, cosine, x, y)
+        CGAffineTransformScale(rotated_transform, self.scaleX, self.scaleY)
       end
 
     end


### PR DESCRIPTION
The physics sprite nodeToParentTransform doesn't respect the scaling of the sprite. This patch adds a scaling step to the affine transform so your sprites can still scale around with all the physics goodness of box2d.

You can check this by setting the scale property of an existing PhysicsSprite instance both with and without this patch applied.
