### PR TITLE
Correct physicssprite position

### DIFF
--- a/motion/joybox/actions/call_block.rb
+++ b/motion/joybox/actions/call_block.rb
@@ -1,0 +1,11 @@
+module Joybox
+  module Actions
+
+    class CallBlock
+      def self.with(&block)
+        CCCallBlockN.actionWithBlock(block)
+      end
+    end
+
+  end
+end

--- a/motion/joybox/physics/physics_sprite.rb
+++ b/motion/joybox/physics/physics_sprite.rb
@@ -19,6 +19,8 @@ module Joybox
       def position=(position)
         if @body
           @body.position = position
+        else
+          super
         end
       end
 
@@ -26,15 +28,15 @@ module Joybox
         if @body
           @body.position
         else
-          [0,0]
-        end  
+          super
+        end
       end
 
       def nodeToParentTransform
         return super if @body.nil?
 
         super
-        
+
         position = @body.position
         position = position + anchorPointInPoints if ignoreAnchorPointForPosition
         angle = @body.angle


### PR DESCRIPTION
It's not super important, but I needed this in one of my games. At the end of a physics animation, I wanted to remove the PhysicsSprite from the screen, without disturbing the other box2d object. So I removed the body from the PhycicsSprite and started applying some cocos2d animations (scale.by and move.to) .Scale.by was working but move.to wasn't…
