### PR TITLE
fix for position() and position= for PhysicsSprite when body is not set

### DIFF
--- a/motion/joybox/physics/physics_sprite.rb
+++ b/motion/joybox/physics/physics_sprite.rb
@@ -19,6 +19,8 @@ module Joybox
       def position=(position)
         if @body
           @body.position = position
+        else
+          super
         end
       end
 
@@ -26,8 +28,8 @@ module Joybox
         if @body
           @body.position
         else
-          [0,0]
-        end  
+          super
+        end
       end
 
       def nodeToParentTransform


### PR DESCRIPTION
The position= and position() method were incorrect when the body was not set (or after the body had been removed). Basically if body is not set, a PhysicsSprite behaves as a regular sprite now.

It's not super important, but I needed this in one of my games. At the end of a physics animation, I wanted to remove the PhysicsSprite from the screen, without disturbing the other box2d object. So I removed the body from the PhysicsSprite and started applying some cocos2d animations (scale.by and move.to) .Scale.by was working but move.to wasn't…

ps: you might received a similar pull request from me a few minutes ago, but I messed things up and had a commit from another pulled request mixed in... I delete the previous branch and recreated this branch with only this one commit (not sure if github recalled the previous pullrequest though...)
