### PR TITLE
SpriteFrameCache: custom order option for :where

### DIFF
--- a/motion/joybox/core/sprite_frame_cache.rb
+++ b/motion/joybox/core/sprite_frame_cache.rb
@@ -76,21 +76,22 @@ class CCSpriteFrameCache
 
     frames = Array.new
 
-    from_frame = options[:from]
+    frame_order = options[:order]
+    from_frame = frame_order ? frame_order.pop : options[:from]
     to_frame = options[:to]
 
     frame = nil
     
     # Yukihiro Matsumoto recomends using loop instead of while or until statements
     # http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/6745
-    loop do  
+    loop do
       frame_name = "#{frame_prefix}#{from_frame}#{frame_suffix}"
       frame = self[frame_name]
       frames << frame unless frame.nil?
 
-      from_frame = from_frame + 1
+      from_frame = frame_order ? frame_order.pop : (from_frame + 1)
       break if frame.nil? or (from_frame > to_frame unless to_frame.nil?)
-    end 
+    end
 
     frames
   end

--- a/spec/motion/joybox/core/sprite_frame_cache_spec.rb
+++ b/spec/motion/joybox/core/sprite_frame_cache_spec.rb
@@ -98,5 +98,14 @@ describe Joybox::Core::SpriteFrameCache do
       end
       sprite_frames.size.should == 1
     end
+
+    it "should get frames using a prefix, suffix and order" do
+      sprite_frames = SpriteFrameCache.frames.where prefix: "bear", suffix: ".png", order: [1, 5, 3]
+      sprite_frames.each do |frame|
+        frame.texture.should.not == nil
+        frame.rect.should.not == CGRectMake(0, 0, 0, 0)
+      end
+      sprite_frames.size.should == 3
+    end
   end
 end


### PR DESCRIPTION
With this change you will be able to retrieve sprites from the Sprite Sheet
in an order that is not necessarily sequential and can show a single
frame several times in the animation.

Example:

```
frames = SpriteFrameCache.frames.where prefix: "bear", suffix: ".png", order: [1, 5, 3, 5, 3, 1]
```

NOTE: I am not experienced with Joybox yet, maybe there is something already in place to achieve the same thing?
