### PR TITLE
Add default .gitignore file to templates

### DIFF
--- a/template/joybox-ios-example-repl/files/.gitignore
+++ b/template/joybox-ios-example-repl/files/.gitignore
@@ -1,0 +1,16 @@
+.repl_history
+build
+tags
+app/pixate_code.rb
+resources/*.nib
+resources/*.momd
+resources/*.storyboardc
+.DS_Store
+nbproject
+.redcar
+#*#
+*~
+*.sw[po]
+.eprj
+.sass-cache
+.idea

--- a/template/joybox-ios/files/.gitignore
+++ b/template/joybox-ios/files/.gitignore
@@ -1,0 +1,16 @@
+.repl_history
+build
+tags
+app/pixate_code.rb
+resources/*.nib
+resources/*.momd
+resources/*.storyboardc
+.DS_Store
+nbproject
+.redcar
+#*#
+*~
+*.sw[po]
+.eprj
+.sass-cache
+.idea

--- a/template/joybox-osx-example-repl/files/.gitignore
+++ b/template/joybox-osx-example-repl/files/.gitignore
@@ -1,0 +1,16 @@
+.repl_history
+build
+tags
+app/pixate_code.rb
+resources/*.nib
+resources/*.momd
+resources/*.storyboardc
+.DS_Store
+nbproject
+.redcar
+#*#
+*~
+*.sw[po]
+.eprj
+.sass-cache
+.idea

--- a/template/joybox-osx/files/.gitignore
+++ b/template/joybox-osx/files/.gitignore
@@ -1,0 +1,16 @@
+.repl_history
+build
+tags
+app/pixate_code.rb
+resources/*.nib
+resources/*.momd
+resources/*.storyboardc
+.DS_Store
+nbproject
+.redcar
+#*#
+*~
+*.sw[po]
+.eprj
+.sass-cache
+.idea


### PR DESCRIPTION
Templates were missing the Rubymotion default .gitignore file, thus, when you created a new Joybox app you were not getting it.

Not sure this is the right solution, it might be that Rubymotion should handle this by default, but this should do for now.
