### PR TITLE
Add enumerable and indexing to CCArray.

### DIFF
--- a/motion/joybox/common/cc_array.rb
+++ b/motion/joybox/common/cc_array.rb
@@ -1,0 +1,11 @@
+class CCArray
+    include Enumerable
+
+    def [] index
+        self.objectAtIndex(index)
+    end
+
+    def each(&blk)
+        self.getNSArray.each(&blk)
+    end
+end


### PR DESCRIPTION
This adds enumerable functionality to the CCArray class, so you can map and filter children of a ccnode - and when you're screwing around in the repl

```
self.director.runningScene.children.getNSArray[0]
```

becomes

```
self.director.runningScene.children[0]
```
