### PR TITLE
Fix: Modify `Joybox::Core::LayerColor.new` to return LayerColor instance...

### DIFF
--- a/motion/joybox/core/layer_color.rb
+++ b/motion/joybox/core/layer_color.rb
@@ -6,10 +6,10 @@ module Joybox
       include Joybox::Common
 
       def self.scene
-        define_singleton_method(:scene) do 
+        define_singleton_method(:scene) do |options = {}|
           scene = CCScene.new
-          menu_layer = self.new
-          scene << menu_layer
+          layer = self.new(options)
+          scene << layer
         end
       end
 
@@ -32,17 +32,17 @@ module Joybox
       end
 
       def self.new(options = {})
-        options = options.nil? ? defaults : defaults.merge!(options)
+        options = defaults.merge(options)
         options[:color] << options[:opacity]
 
-        layer = CCLayerColor.layerWithColor(options[:color], 
-                                            width: options[:width], 
-                                            height: options[:height])
+        layer = self.layerWithColor(options[:color],
+                                    width: options[:width],
+                                    height: options[:height])
 
         layer.position = options[:position] if options.has_key? :position
         layer
       end
-      
+
     end
 
   end

--- a/spec/motion/joybox/core/layer_color_spec.rb
+++ b/spec/motion/joybox/core/layer_color_spec.rb
@@ -1,0 +1,29 @@
+describe Joybox::Core::LayerColor do
+
+  describe "LayerColor.new" do
+    it "should initialize with options" do
+      layer = Joybox::Core::LayerColor.new(
+        color: "800617".to_color,
+        width: 100,
+        height: 100,
+        position: [100, 100],
+        opacity: 100)
+      layer.should.not == nil
+      layer.position.should == CGPoint.new(100, 100)
+      layer.color.should == CcColor3B.new(*("800617".unpack("a2a2a2").map { |x| x.to_i(16) }))
+      layer.opacity.should == 100
+      layer.visible.should == true
+      layer.class.should == Joybox::Core::LayerColor
+    end
+  end
+
+  describe "LayerColor.scene" do
+    it "should define singleton method and return CCScene with LayerColor" do
+      Joybox::Core::LayerColor.scene
+      scene = Joybox::Core::LayerColor.scene(color: [1, 2, 3])
+      scene.class.should == CCScene
+      scene.children.first.class.should == Joybox::Core::LayerColor
+    end
+  end
+
+end


### PR DESCRIPTION
Hi.

`Joybox::Core::LayerColor.new` is expected to return `Joybox::Core::LayerColor` instance.
However, it returns CCLayerColor, and its instance is not callable `on_enter` method of course.
This c679069 commit fixes this.

and..
- modify defined `Joybox::Core::LayerColor.scene` to accept arguments for color.
- add spec

thanks.
