### PR TITLE
Avoid overwriting mutable array in passed hash when LayerColor.new.

### DIFF
--- a/motion/joybox/core/layer_color.rb
+++ b/motion/joybox/core/layer_color.rb
@@ -33,9 +33,8 @@ module Joybox
 
       def self.new(options = {})
         opts = defaults.merge(options)
-        opts[:color] << opts[:opacity]
 
-        layer = self.layerWithColor(opts[:color],
+        layer = self.layerWithColor(Array[*opts[:color], opts[:opacity]],
                                     width: opts[:width],
                                     height: opts[:height])
 

--- a/motion/joybox/core/layer_color.rb
+++ b/motion/joybox/core/layer_color.rb
@@ -24,22 +24,22 @@ module Joybox
       end
 
       def self.defaults
-      {
-        opacity: 255,
-        width: Screen.width,
-        height: Screen.height
-      }
+        {
+          opacity: 255,
+          width: Screen.width,
+          height: Screen.height
+        }
       end
 
       def self.new(options = {})
-        options = defaults.merge(options)
-        options[:color] << options[:opacity]
+        opts = defaults.merge(options)
+        opts[:color] << opts[:opacity]
 
-        layer = self.layerWithColor(options[:color],
-                                    width: options[:width],
-                                    height: options[:height])
+        layer = self.layerWithColor(opts[:color],
+                                    width: opts[:width],
+                                    height: opts[:height])
 
-        layer.position = options[:position] if options.has_key? :position
+        layer.position = opts[:position] if opts[:position]
         layer
       end
 

--- a/motion/joybox/core/layer_color.rb
+++ b/motion/joybox/core/layer_color.rb
@@ -32,13 +32,14 @@ module Joybox
       end
 
       def self.new(options = {})
-        opts = defaults.merge(options)
+        options = defaults.merge(options)
+        color_with_opacity = options[:color].dup << options[:opacity]
 
-        layer = self.layerWithColor(Array[*opts[:color], opts[:opacity]],
-                                    width: opts[:width],
-                                    height: opts[:height])
+        layer = self.layerWithColor(color_with_opacity,
+                                    width: options[:width],
+                                    height: options[:height])
 
-        layer.position = opts[:position] if opts[:position]
+        layer.position = options[:position] if options[:position]
         layer
       end
 


### PR DESCRIPTION
Hi. `Joybox::Core::LayerColor.new` should be avoided side-effect to passed options.
please see below.

``` ruby
my_opts = {color: [255, 255, 255]}
Joybox::Core::LayerColor.new(my_opts)
Joybox::Core::LayerColor.new(my_opts) # => layer_color.rb:40:in `new:': expected Array of 4 elements, got 5 (ArgumentError)
```

thanks.
